### PR TITLE
Potential fix for code scanning alert no. 5: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -307,5 +307,6 @@ def check_pass_fail_unknown(data, file_path, received_subject):
 
 
 if __name__ == '__main__':  # pragma: no cover
-    # Running in debug mode is useful during development.
-    app.run(debug=True)
+    # Enable debug only when explicitly requested via environment.
+    debug_mode = os.getenv("FLASK_DEBUG", "").strip().lower() in ("1", "true", "yes", "on")
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/silpol/mailgun-mail-store/security/code-scanning/5](https://github.com/silpol/mailgun-mail-store/security/code-scanning/5)

The safest fix is to stop hardcoding `debug=True` and default to `False`, while still allowing developers to enable debug intentionally via an environment variable. This preserves functionality (you can still run in debug during development) without shipping an insecure default.

In `app.py`, replace the `app.run(debug=True)` call in the `if __name__ == '__main__':` block with an environment-controlled boolean (defaulting to `False`). Since `os` is already imported in the snippet, no new import is needed.

Recommended change in that block:
- Read `FLASK_DEBUG` from environment.
- Interpret common truthy values (`1`, `true`, `yes`, `on`) as enabling debug.
- Call `app.run(debug=debug_mode)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
